### PR TITLE
PCRR-411 Fix Analytics page being blocked by uBlock Origin

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,7 +33,13 @@ const nextConfig = {
           }
         }
       },
-      )
+    )
+
+    // Prevent Analytics page from being blocked by uBlock Origin.
+    if (config.output.filename === 'static/chunks/[name]-[contenthash].js') {
+      config.output.filename = 'static/chunks/[name].bundle.[contenthash].js'
+    }
+
     return config
   },
 }


### PR DESCRIPTION
The Analytics page is blocked because the particular Next.js/webpack output bundle filename is blacklisted by uBlock Origin for whatever reason. Choosing non-standard bundle names fixes the issue.

Note that my battle against the Next.js build system took a while.